### PR TITLE
Add confirmation dialog when leaving form page

### DIFF
--- a/survey/static/survey/js/form.js
+++ b/survey/static/survey/js/form.js
@@ -21,3 +21,13 @@ function sendModalData(event) {
     );
     posting.done(displayModalContent);
 }
+
+$(window).on(
+    "beforeunload",
+    function(e) {
+        e.preventDefault();
+        // Newer browsers ignore the return value, but certain older browsers display this in the dialog.
+        e.returnValue = "Do you want to leave the survey page? Changes you made may not be saved.";
+        return "Do you want to leave the survey page? Changes you made may not be saved.";
+    }
+);

--- a/survey/templates/survey/form.html
+++ b/survey/templates/survey/form.html
@@ -121,7 +121,7 @@
             <a href="{% url 'survey:index' %}" class="btn btn-secondary">Back to index</a>
         </div>
         <div class="col-auto">
-            <input class="btn btn-primary" type="submit" value="Submit">
+            <input class="btn btn-primary" type="submit" value="Submit" onclick="$(window).off('beforeunload')">
         </div>
     </div>
 </form>


### PR DESCRIPTION
Adds a confirmation dialog when leaving a survey page (excluding when hitting the submit button) to prevent users from accidentally leaving the form page and losing whatever data they may have entered. Resolves #42.