### PR TITLE
Gender-specific results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ cache/*.djcache
 */static/**/css/*
 
 startserver.ps1
+*.bat
 *.tsv
 
 # Backup files # 

--- a/survey/static/survey/js/fullresults.js
+++ b/survey/static/survey/js/fullresults.js
@@ -59,6 +59,16 @@ const columnTypes = {
         label: "Pop\u00adu\u00adlar\u00adi\u00adty",
         formatter: percentageFormatter,
     },
+    popularity_male: {
+        key: "popularity_male",
+        label: "Pop\u00adu\u00adlar\u00adi\u00adty (Male)",
+        formatter: percentageFormatter,
+    },
+    popularity_female: {
+        key: "popularity_female",
+        label: "Pop\u00adu\u00adlar\u00adi\u00adty (Female)",
+        formatter: percentageFormatter,
+    },
     gender_popularity_ratio: {
         key: "gender_popularity_ratio",
         label: "Gen\u00adder Ra\u00adtio",
@@ -77,6 +87,16 @@ const columnTypes = {
     score: {
         key: "score",
         label: "Score",
+        formatter: scoreFormatter,
+    },
+    score_male: {
+        key: "score_male",
+        label: "Score (Male)",
+        formatter: scoreFormatter,
+    },
+    score_female: {
+        key: "score_female",
+        label: "Score (Female)",
         formatter: scoreFormatter,
     },
     gender_score_difference: {
@@ -106,12 +126,16 @@ for (let column_idx in columnTypes) {
 const animeSeriesColumns = [].concat([
     columnTypes["name"],
     columnTypes["popularity"],
+    columnTypes["popularity_male"],
+    columnTypes["popularity_female"],
     columnTypes["gender_popularity_ratio"],
     columnTypes["age"]],
     !surveyIsPreseason ? [
         columnTypes["underwatched"]
     ] : [], [
     columnTypes["score"],
+    columnTypes["score_male"],
+    columnTypes["score_female"],
     columnTypes["gender_score_difference"]],
     !surveyIsPreseason ? [
         columnTypes["surprise"], columnTypes["disappointment"]

--- a/survey/static/survey/js/fullresults.js
+++ b/survey/static/survey/js/fullresults.js
@@ -123,19 +123,21 @@ for (let column_idx in columnTypes) {
     column["tdClass"] = column["thClass"];
 }
 
+// TODO: Commenting away gender-specific result types is only done
+// because the full results table as it is now is simply too wide to fit on the page.
 const animeSeriesColumns = [].concat([
     columnTypes["name"],
     columnTypes["popularity"],
-    columnTypes["popularity_male"],
-    columnTypes["popularity_female"],
+    //columnTypes["popularity_male"],
+    //columnTypes["popularity_female"],
     columnTypes["gender_popularity_ratio"],
     columnTypes["age"]],
     !surveyIsPreseason ? [
         columnTypes["underwatched"]
     ] : [], [
     columnTypes["score"],
-    columnTypes["score_male"],
-    columnTypes["score_female"],
+    //columnTypes["score_male"],
+    //columnTypes["score_female"],
     columnTypes["gender_score_difference"]],
     !surveyIsPreseason ? [
         columnTypes["surprise"], columnTypes["disappointment"]
@@ -144,12 +146,23 @@ const animeSeriesColumns = [].concat([
 const specialAnimeColumns = [].concat([
     columnTypes["name"],
     columnTypes["popularity"],
+    //columnTypes["popularity_male"],
+    //columnTypes["popularity_female"],
     columnTypes["gender_popularity_ratio"],
     columnTypes["age"]],
     !surveyIsPreseason ? [
-        columnTypes["score"], columnTypes["gender_score_difference"]
+        columnTypes["score"], columnTypes["gender_score_difference"], //columnTypes["score_male"], columnTypes["score_female"],
     ] : []
 );
+
+// TODO: Gender-specific result types are currently not displayed on the full results page,
+// so the sorting column has to be the non-gender specific one. See the note above.
+if (sortBy === "popularity_male" || sortBy === "popularity_female") {
+    sortBy = "popularity";
+}
+else if (sortBy === "score_male" || sortBy === "score_female") {
+    sortBy = "score";
+}
 
 new Vue({
     el: "#" + animeSeriesTableId,

--- a/survey/static/survey/js/results.js
+++ b/survey/static/survey/js/results.js
@@ -146,6 +146,8 @@ function processData(tableItems, sortKey, sortDesc, topCount, bottomCount) {
     let pbValueConversion = function(value) { return value };
     switch (sortKey) {
         case "score":
+        case "score_male":
+        case "score_female":
             pbMin = 1.0;
             pbMax = 5.0;
             break;

--- a/survey/static/survey/js/results.js
+++ b/survey/static/survey/js/results.js
@@ -22,6 +22,16 @@ const columnTypes = {
         label: "Pop\u00adu\u00adlar\u00adi\u00adty",
         formatter: percentageFormatter,
     },
+    popularity_male: {
+        key: "popularity_male",
+        label: "Pop\u00adu\u00adlar\u00adi\u00adty (Male)",
+        formatter: percentageFormatter,
+    },
+    popularity_female: {
+        key: "popularity_female",
+        label: "Pop\u00adu\u00adlar\u00adi\u00adty (Female)",
+        formatter: percentageFormatter,
+    },
     gender_popularity_ratio: {
         key: "gender_popularity_ratio",
         label: "Gen\u00adder Ra\u00adtio",
@@ -40,6 +50,16 @@ const columnTypes = {
     score: {
         key: "score",
         label: "Score",
+        formatter: scoreFormatter,
+    },
+    score_male: {
+        key: "score_male",
+        label: "Score (Male)",
+        formatter: scoreFormatter,
+    },
+    score_female: {
+        key: "score_female",
+        label: "Score (Female)",
         formatter: scoreFormatter,
     },
     gender_score_difference: {

--- a/survey/static/survey/scss/results.scss
+++ b/survey/static/survey/scss/results.scss
@@ -19,6 +19,23 @@ h4 {
     }
 }
 
+.hidden-group.collapsed {
+    .collapse-button-show-text {
+        display: initial;
+    }
+    .collapse-button-hide-text {
+        display: none;
+    }
+}
+.hidden-group.not-collapsed {
+    .collapse-button-show-text {
+        display: none;
+    }
+    .collapse-button-hide-test {
+        display: initial;
+    }
+}
+
 th div {
     hyphens: manual;
 }

--- a/survey/static/survey/scss/results.scss
+++ b/survey/static/survey/scss/results.scss
@@ -3,10 +3,20 @@
 h1, h2, h3, h4 {
     background-color: #537cf9;
     color: #f4f4fc;
+}
+h1, h2, h3 {
     padding: 13px;
 }
 h4 {
     padding: 7px;
+}
+
+.hidden-group {
+    padding: 0px;
+
+    h1, h2, h3, h4 {
+        margin: 0px;
+    }
 }
 
 th div {

--- a/survey/static/survey/scss/results.scss
+++ b/survey/static/survey/scss/results.scss
@@ -11,15 +11,21 @@ h4 {
     padding: 7px;
 }
 
-.hidden-group {
+.hidden-group-button {
     padding: 0px;
+    background-color: transparent!important;
+    border-color: transparent!important;
+    color: initial!important;
 
     h1, h2, h3, h4 {
         margin: 0px;
     }
+    h1:hover, h2:hover, h3:hover, h4:hover {
+        background-color: scale-color($color: #537cf9, $lightness: -20%)!important;
+    }
 }
 
-.hidden-group.collapsed {
+.hidden-group-button.collapsed {
     .collapse-button-show-text {
         display: initial;
     }
@@ -27,7 +33,7 @@ h4 {
         display: none;
     }
 }
-.hidden-group.not-collapsed {
+.hidden-group-button.not-collapsed {
     .collapse-button-show-text {
         display: none;
     }

--- a/survey/templates/survey/fullresults.html
+++ b/survey/templates/survey/fullresults.html
@@ -34,7 +34,7 @@
     const surveyIsPreseason = {{ survey.is_preseason|lower }};
     const animeSeriesTableId = "{{ anime_series_table_id }}";
     const specialAnimeTableId = "{{ special_anime_table_id }}";
-    const sortBy = "{{ sort_by }}";
+    let sortBy = "{{ sort_by }}";
 </script>
 <script src="{% static 'survey/js/results-table-formatters.js' %}"></script>
 <script src="{% static 'survey/js/fullresults.js' %}"></script>

--- a/survey/templates/survey/results.html
+++ b/survey/templates/survey/results.html
@@ -43,7 +43,9 @@
 </div>
 
 
-{% include 'survey/results_item_group.html' with depth=2 item=root_item survey=survey only%}
+<div id="results-content">
+    {% include 'survey/results_item_group.html' with depth=2 item=root_item survey=survey only%}
+</div>
 
 
 <div class="row justify-content-between mt-3">
@@ -55,8 +57,19 @@
     </div>
 </div>
 
+<script>
+    const data = {};
+</script>
+
+{% include 'survey/results_item_group-js.html' with item=root_item survey=survey only %}
 
 <script>
+    new Vue({
+        el: "#results-content",
+        delimiters: ["{$", "$}"],
+        data: data,
+    });
+
     const textColor = "#080421";
     const chartDataColor = "#537cf9";
     const chartDatalabelColor = textColor;

--- a/survey/templates/survey/results_item_group-js.html
+++ b/survey/templates/survey/results_item_group-js.html
@@ -1,0 +1,11 @@
+{% for child in item.children %}{% with item_type=child.item_type.name %}
+    {% if item_type == 'GROUP' or item_type == 'HIDDEN_GROUP' %}
+        {% include 'survey/results_item_group-js.html' with depth=depth|add:'1' survey=survey item=child only %}
+    {% elif item_type == 'TABLE_WITH_TOP3' %}
+        {% include 'survey/results_item_table-with-top3-js.html' with depth=depth|add:'1' survey=survey item=child only %}
+    {% elif item_type == 'TABLE_PAIR' %}
+        {% include 'survey/results_item_table-pair-js.html' with depth=depth|add:'1' survey=survey item=child only %}
+    {% elif item_type == 'EMPTY' %}
+    {% else %}
+    {% endif %}
+{% endwith %}{% endfor %}

--- a/survey/templates/survey/results_item_group.html
+++ b/survey/templates/survey/results_item_group.html
@@ -6,6 +6,8 @@
     {% for child in item.children %}{% with item_type=child.item_type.name %}
         {% if item_type == 'GROUP' %}
             {% include 'survey/results_item_group.html' with depth=depth|add:'1' survey=survey item=child only %}
+        {% elif item_type == 'HIDDEN_GROUP' %}
+            {% include 'survey/results_item_hidden-group.html' with depth=depth|add:'1' survey=survey item=child only %}
         {% elif item_type == 'TABLE_WITH_TOP3' %}
             {% include 'survey/results_item_table-with-top3.html' with depth=depth|add:'1' survey=survey item=child only %}
         {% elif item_type == 'TABLE_PAIR' %}

--- a/survey/templates/survey/results_item_group.html
+++ b/survey/templates/survey/results_item_group.html
@@ -1,8 +1,8 @@
 {% if item.title %}
-<h{{ depth }} class="rounded shadow">{{ item.title }}</h{{ depth }}>
+<h{{ depth }} class="rounded shadow mt-4">{{ item.title }}</h{{ depth }}>
 {% endif %}
 
-<div class="container-fluid mt-4 px-2 bg-lighter">
+<div class="container-fluid px-2 bg-lighter">
     {% for child in item.children %}{% with item_type=child.item_type.name %}
         {% if item_type == 'GROUP' %}
             {% include 'survey/results_item_group.html' with depth=depth|add:'1' survey=survey item=child only %}

--- a/survey/templates/survey/results_item_hidden-group.html
+++ b/survey/templates/survey/results_item_hidden-group.html
@@ -1,10 +1,12 @@
 <div>
     <b-button v-b-toggle.collapse-{{ item.id }} class="w-100 mb-4 hidden-group">
         <h{{ depth }}>
+            <span class="collapse-button-show-text">Show</span>
+            <span class="collapse-button-hide-text">Hide</span>
             {% if item.title %}
-                Show {{ item.title }}
+                {{ item.title }}
             {% else %}
-                Show content
+                content
             {% endif %}
         </h{{ depth }}>
     </b-button>

--- a/survey/templates/survey/results_item_hidden-group.html
+++ b/survey/templates/survey/results_item_hidden-group.html
@@ -1,6 +1,6 @@
-<div>
-    <b-button v-b-toggle.collapse-{{ item.id }} class="w-100 mb-4 hidden-group">
-        <h{{ depth }}>
+<div class="px-2 mt-4">
+    <b-button v-b-toggle.collapse-{{ item.id }} variant="light" class="w-100 hidden-group-button">
+        <h{{ depth }} class="rounded shadow">
             <span class="collapse-button-show-text">Show</span>
             <span class="collapse-button-hide-text">Hide</span>
             {% if item.title %}
@@ -10,10 +10,10 @@
             {% endif %}
         </h{{ depth }}>
     </b-button>
-    <b-collapse id="collapse-{{ item.id }}" class="mt-2">
+    <b-collapse id="collapse-{{ item.id }}" class="mt-1">
         <b-card>
 
-            <div class="container-fluid mt-4 px-2 bg-lighter">
+            <div class="container-fluid bg-lighter">
                 {% for child in item.children %}{% with item_type=child.item_type.name %}
                     {% if item_type == 'GROUP' %}
                         {% include 'survey/results_item_group.html' with depth=depth|add:'1' survey=survey item=child only %}

--- a/survey/templates/survey/results_item_hidden-group.html
+++ b/survey/templates/survey/results_item_hidden-group.html
@@ -1,41 +1,34 @@
+<div>
+    <b-button v-b-toggle.collapse-{{ item.id }} class="w-100 mb-4 hidden-group">
+        <h{{ depth }}>
+            {% if item.title %}
+                Show {{ item.title }}
+            {% else %}
+                Show content
+            {% endif %}
+        </h{{ depth }}>
+    </b-button>
+    <b-collapse id="collapse-{{ item.id }}" class="mt-2">
+        <b-card>
 
-
-<div class="accordion" id="accordionExample">
-    <div class="card">
-        <div class="card-header" id="headingOne">
-            <h2 class="mb-0">
-                <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-                    <span class="rounded shadow">
-                        {% if item.title %}
-                            {{ item.title }}
-                        {% else %}
-                            Show content
-                        {% endif %}
-                    </span>
-                </button>
-            </h2>
-        </div>
-
-        <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
-            <div class="card-body">
-                <div class="container-fluid mt-4 px-2 bg-lighter">
-                    {% for child in item.children %}{% with item_type=child.item_type.name %}
-                        {% if item_type == 'GROUP' %}
-                            {% include 'survey/results_item_group.html' with depth=depth|add:'1' survey=survey item=child only %}
-                        {% elif item_type == 'HIDDEN_GROUP' %}
-                            {% include 'survey/results_item_hidden-group.html' with depth=depth|add:'1' survey=survey item=child only %}
-                        {% elif item_type == 'TABLE_WITH_TOP3' %}
-                            {% include 'survey/results_item_table-with-top3.html' with depth=depth|add:'1' survey=survey item=child only %}
-                        {% elif item_type == 'TABLE_PAIR' %}
-                            {% include 'survey/results_item_table-pair.html' with depth=depth|add:'1' survey=survey item=child only %}
-                        {% elif item_type == 'EMPTY' %}
-                        {% else %}
-                            <h{{ depth|add:'1' }}>{{ child.title }}</h{{ depth|add:'1' }}>
-                            <p>Unknown item type: {{ item_type }}</p>
-                        {% endif %}
-                    {% endwith %}{% endfor %}
-                </div>
+            <div class="container-fluid mt-4 px-2 bg-lighter">
+                {% for child in item.children %}{% with item_type=child.item_type.name %}
+                    {% if item_type == 'GROUP' %}
+                        {% include 'survey/results_item_group.html' with depth=depth|add:'1' survey=survey item=child only %}
+                    {% elif item_type == 'HIDDEN_GROUP' %}
+                        {% include 'survey/results_item_hidden-group.html' with depth=depth|add:'1' survey=survey item=child only %}
+                    {% elif item_type == 'TABLE_WITH_TOP3' %}
+                        {% include 'survey/results_item_table-with-top3.html' with depth=depth|add:'1' survey=survey item=child only %}
+                    {% elif item_type == 'TABLE_PAIR' %}
+                        {% include 'survey/results_item_table-pair.html' with depth=depth|add:'1' survey=survey item=child only %}
+                    {% elif item_type == 'EMPTY' %}
+                    {% else %}
+                        <h{{ depth|add:'1' }}>{{ child.title }}</h{{ depth|add:'1' }}>
+                        <p>Unknown item type: {{ item_type }}</p>
+                    {% endif %}
+                {% endwith %}{% endfor %}
             </div>
-        </div>
-    </div>
+
+        </b-card>
+    </b-collapse>
 </div>

--- a/survey/templates/survey/results_item_hidden-group.html
+++ b/survey/templates/survey/results_item_hidden-group.html
@@ -1,0 +1,41 @@
+
+
+<div class="accordion" id="accordionExample">
+    <div class="card">
+        <div class="card-header" id="headingOne">
+            <h2 class="mb-0">
+                <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                    <span class="rounded shadow">
+                        {% if item.title %}
+                            {{ item.title }}
+                        {% else %}
+                            Show content
+                        {% endif %}
+                    </span>
+                </button>
+            </h2>
+        </div>
+
+        <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+            <div class="card-body">
+                <div class="container-fluid mt-4 px-2 bg-lighter">
+                    {% for child in item.children %}{% with item_type=child.item_type.name %}
+                        {% if item_type == 'GROUP' %}
+                            {% include 'survey/results_item_group.html' with depth=depth|add:'1' survey=survey item=child only %}
+                        {% elif item_type == 'HIDDEN_GROUP' %}
+                            {% include 'survey/results_item_hidden-group.html' with depth=depth|add:'1' survey=survey item=child only %}
+                        {% elif item_type == 'TABLE_WITH_TOP3' %}
+                            {% include 'survey/results_item_table-with-top3.html' with depth=depth|add:'1' survey=survey item=child only %}
+                        {% elif item_type == 'TABLE_PAIR' %}
+                            {% include 'survey/results_item_table-pair.html' with depth=depth|add:'1' survey=survey item=child only %}
+                        {% elif item_type == 'EMPTY' %}
+                        {% else %}
+                            <h{{ depth|add:'1' }}>{{ child.title }}</h{{ depth|add:'1' }}>
+                            <p>Unknown item type: {{ item_type }}</p>
+                        {% endif %}
+                    {% endwith %}{% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/survey/templates/survey/results_item_table-base.html
+++ b/survey/templates/survey/results_item_table-base.html
@@ -1,6 +1,6 @@
 <div class="row row-cols-1">
     <div class="col">
-        <b-table-lite hover small borderless :items="{{ table_items_var }}" :fields="fields">
+        <b-table-lite hover small borderless :items="{{ table_items_var }}" :fields="tableColumns{{ item_id }}">
             <template #cell(rank)="data">
                 <template v-if="data.value">
                     #{$ data.value $}

--- a/survey/templates/survey/results_item_table-base.html
+++ b/survey/templates/survey/results_item_table-base.html
@@ -1,6 +1,6 @@
 <div class="row row-cols-1">
     <div class="col">
-        <b-table-lite hover small borderless :items="{{ table_items_var }}" :fields="tableColumns{{ item_id }}">
+        <b-table-lite hover small borderless :items="{{ table_items_var }}" :fields="{{ table_fields_var }}">
             <template #cell(rank)="data">
                 <template v-if="data.value">
                     #{$ data.value $}

--- a/survey/templates/survey/results_item_table-pair-js.html
+++ b/survey/templates/survey/results_item_table-pair-js.html
@@ -1,0 +1,32 @@
+<script>
+const tableMainResult{{ item.id }} = "{{ item.main_result_type.name|lower }}";
+const tableExtraResult{{ item.id }} = "{{ item.extra_result_type.name|lower|default:'' }}";
+
+const tableColumns{{ item.id }} = [
+    columnTypes["rank"],
+    columnTypes["image"],
+    columnTypes["name"],
+].concat(
+    [setColumnCssClass(columnTypes[tableMainResult{{ item.id }}], "table-col-main")],
+    tableExtraResult{{ item.id }} ? [setColumnCssClass(columnTypes[tableExtraResult{{ item.id }}], "table-col-extra")] : []
+);
+
+const tableItems{{ item.id }}Left = processData(
+    getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
+    tableMainResult{{ item.id }},
+    true,
+    {{ item.top_count|default:'null' }},
+    {{ item.bottom_count|default:'null' }}
+);
+const tableItems{{ item.id }}Right = processData(
+    getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
+    tableMainResult{{ item.id }},
+    false,
+    {{ item.top_count|default:'null' }},
+    {{ item.bottom_count|default:'null' }}
+);
+
+data["tableColumns{{ item.id }}"] = tableColumns{{ item.id }};
+data["tableItems{{ item.id }}Left"] = tableItems{{ item.id }}Left;
+data["tableItems{{ item.id }}Right"] = tableItems{{ item.id }}Right;
+</script>

--- a/survey/templates/survey/results_item_table-pair-js.html
+++ b/survey/templates/survey/results_item_table-pair-js.html
@@ -1,13 +1,22 @@
 <script>
 const tableMainResult{{ item.id }} = "{{ item.main_result_type.name|lower }}";
+const tableInverseResult{{ item.id }} = "{{ item.inverse_result_type.name|lower }}";
 const tableExtraResult{{ item.id }} = "{{ item.extra_result_type.name|lower|default:'' }}";
 
-const tableColumns{{ item.id }} = [
+const tableColumns{{ item.id }}Left = [
     columnTypes["rank"],
     columnTypes["image"],
     columnTypes["name"],
 ].concat(
     [setColumnCssClass(columnTypes[tableMainResult{{ item.id }}], "table-col-main")],
+    tableExtraResult{{ item.id }} ? [setColumnCssClass(columnTypes[tableExtraResult{{ item.id }}], "table-col-extra")] : []
+);
+const tableColumns{{ item.id }}Right = [
+    columnTypes["rank"],
+    columnTypes["image"],
+    columnTypes["name"],
+].concat(
+    [setColumnCssClass(columnTypes[tableInverseResult{{ item.id }} ? tableInverseResult{{ item.id }} : tableMainResult{{ item.id }}], "table-col-main")],
     tableExtraResult{{ item.id }} ? [setColumnCssClass(columnTypes[tableExtraResult{{ item.id }}], "table-col-extra")] : []
 );
 
@@ -18,15 +27,30 @@ const tableItems{{ item.id }}Left = processData(
     {{ item.top_count|default:'null' }},
     {{ item.bottom_count|default:'null' }}
 );
-const tableItems{{ item.id }}Right = processData(
-    getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
-    tableMainResult{{ item.id }},
-    false,
-    {{ item.top_count|default:'null' }},
-    {{ item.bottom_count|default:'null' }}
-);
 
-data["tableColumns{{ item.id }}"] = tableColumns{{ item.id }};
+let tableItems{{ item.id }}Right = "";
+
+if (tableInverseResult{{ item.id }}) {
+    tableItems{{ item.id }}Right = processData(
+        getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
+        tableInverseResult{{ item.id }},
+        true,
+        {{ item.top_count|default:'null' }},
+        {{ item.bottom_count|default:'null' }}
+    );
+}
+else {
+    tableItems{{ item.id }}Right = processData(
+        getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
+        tableMainResult{{ item.id }},
+        false,
+        {{ item.top_count|default:'null' }},
+        {{ item.bottom_count|default:'null' }}
+    );
+}
+
+data["tableColumns{{ item.id }}Left"] = tableColumns{{ item.id }}Left;
+data["tableColumns{{ item.id }}Right"] = tableColumns{{ item.id }}Right;
 data["tableItems{{ item.id }}Left"] = tableItems{{ item.id }}Left;
 data["tableItems{{ item.id }}Right"] = tableItems{{ item.id }}Right;
 </script>

--- a/survey/templates/survey/results_item_table-pair.html
+++ b/survey/templates/survey/results_item_table-pair.html
@@ -1,5 +1,5 @@
 {% with item_id=item.id|stringformat:'i' %}
-{% with table_items_left_var='tableItems'|add:item_id|add:'Left' table_items_right_var='tableItems'|add:item_id|add:'Right' %}
+{% with table_items_left_var='tableItems'|add:item_id|add:'Left' table_items_right_var='tableItems'|add:item_id|add:'Right' table_fields_left_var='tableColumns'|add:item_id|add:'Left' table_fields_right_var='tableColumns'|add:item_id|add:'Right' %}
 
 <h5 class="table-title mb-4">{{ item.title }}</h5>
 
@@ -9,10 +9,14 @@
 
 <div class="row mb-5 no-gutters table-duo" id="results-table-{{ item.id }}">
     <div class="col-md-6 col-12 pl-md-1 pr-md-3">
-        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_left_var  item_id=item.id survey=survey main_result_type=item.main_result_type.name|lower only %}
+        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_left_var table_fields_var=table_fields_left_var survey=survey main_result_type=item.main_result_type.name|lower only %}
     </div>
     <div class="col-md-6 col-12 pl-md-3 pr-md-1">
-        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_right_var item_id=item.id survey=survey main_result_type=item.main_result_type.name|lower only %}
+        {% if item.inverse_result_type %}
+            {% include 'survey/results_item_table-base.html' with table_items_var=table_items_right_var table_fields_var=table_fields_right_var survey=survey main_result_type=item.inverse_result_type.name|lower only%}
+        {% else %}
+            {% include 'survey/results_item_table-base.html' with table_items_var=table_items_right_var table_fields_var=table_fields_left_var survey=survey main_result_type=item.main_result_type.name|lower only %}
+        {% endif %}
     </div>
 </div>
 

--- a/survey/templates/survey/results_item_table-pair.html
+++ b/survey/templates/survey/results_item_table-pair.html
@@ -1,4 +1,5 @@
-{% with table_items_left_var='itemsLeft' table_items_right_var='itemsRight' %}
+{% with item_id=item.id|stringformat:'i' %}
+{% with table_items_left_var='tableItems'|add:item_id|add:'Left' table_items_right_var='tableItems'|add:item_id|add:'Right' %}
 
 <h5 class="table-title mb-4">{{ item.title }}</h5>
 
@@ -8,50 +9,12 @@
 
 <div class="row mb-5 no-gutters table-duo" id="results-table-{{ item.id }}">
     <div class="col-md-6 col-12 pl-md-1 pr-md-3">
-        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_left_var survey=survey main_result_type=item.main_result_type.name|lower only %}
+        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_left_var  item_id=item.id survey=survey main_result_type=item.main_result_type.name|lower only %}
     </div>
     <div class="col-md-6 col-12 pl-md-3 pr-md-1">
-        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_right_var survey=survey main_result_type=item.main_result_type.name|lower only %}
+        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_right_var item_id=item.id survey=survey main_result_type=item.main_result_type.name|lower only %}
     </div>
 </div>
 
-<script>
-const tableMainResult{{ item.id }} = "{{ item.main_result_type.name|lower }}";
-const tableExtraResult{{ item.id }} = "{{ item.extra_result_type.name|lower|default:'' }}";
-
-const tableColumns{{ item.id }} = [
-    columnTypes["rank"],
-    columnTypes["image"],
-    columnTypes["name"],
-].concat(
-    [setColumnCssClass(columnTypes[tableMainResult{{ item.id }}], "table-col-main")],
-    tableExtraResult{{ item.id }} ? [setColumnCssClass(columnTypes[tableExtraResult{{ item.id }}], "table-col-extra")] : []
-);
-
-const tableItems{{ item.id }}Left = processData(
-    getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
-    tableMainResult{{ item.id }},
-    true,
-    {{ item.top_count|default:'null' }},
-    {{ item.bottom_count|default:'null' }}
-);
-const tableItems{{ item.id }}Right = processData(
-    getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
-    tableMainResult{{ item.id }},
-    false,
-    {{ item.top_count|default:'null' }},
-    {{ item.bottom_count|default:'null' }}
-);
-
-new Vue({
-    el: "#results-table-{{ item.id }}",
-    delimiters: ["{$", "$}"],
-    data: {
-        fields: tableColumns{{ item.id }},
-        {{ table_items_left_var }}: tableItems{{ item.id }}Left,
-        {{ table_items_right_var }}: tableItems{{ item.id }}Right,
-    },
-});
-</script>
-
+{% endwith %}
 {% endwith %}

--- a/survey/templates/survey/results_item_table-pair.html
+++ b/survey/templates/survey/results_item_table-pair.html
@@ -1,13 +1,13 @@
 {% with item_id=item.id|stringformat:'i' %}
 {% with table_items_left_var='tableItems'|add:item_id|add:'Left' table_items_right_var='tableItems'|add:item_id|add:'Right' table_fields_left_var='tableColumns'|add:item_id|add:'Left' table_fields_right_var='tableColumns'|add:item_id|add:'Right' %}
 
-<h5 class="table-title mb-4">{{ item.title }}</h5>
+<h5 class="table-title mt-4 mb-3">{{ item.title }}</h5>
 
 {% if item.description %}
-    <p class="table-description mt-n4 mb-4">{{ item.description }}</p>
+    <p class="table-description mt-n3 mb-3">{{ item.description }}</p>
 {% endif %}
 
-<div class="row mb-5 no-gutters table-duo" id="results-table-{{ item.id }}">
+<div class="row no-gutters table-duo" id="results-table-{{ item.id }}">
     <div class="col-md-6 col-12 pl-md-1 pr-md-3">
         {% include 'survey/results_item_table-base.html' with table_items_var=table_items_left_var table_fields_var=table_fields_left_var survey=survey main_result_type=item.main_result_type.name|lower only %}
     </div>

--- a/survey/templates/survey/results_item_table-with-top3-js.html
+++ b/survey/templates/survey/results_item_table-with-top3-js.html
@@ -1,0 +1,24 @@
+<script>
+const tableMainResult{{ item.id }} = "{{ item.main_result_type.name|lower }}";
+const tableExtraResult{{ item.id }} = "{{ item.extra_result_type.name|lower|default:'' }}";
+
+const tableColumns{{ item.id }} = [
+    columnTypes["rank"],
+    columnTypes["image"],
+    columnTypes["name"],
+].concat(
+    [setColumnCssClass(columnTypes[tableMainResult{{ item.id }}], "table-col-main")],
+    tableExtraResult{{ item.id }} ? [setColumnCssClass(columnTypes[tableExtraResult{{ item.id }}], "table-col-extra")] : []
+);
+
+const tableItems{{ item.id }} = processData(
+    getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
+    tableMainResult{{ item.id }},
+    true,
+    {{ item.top_count|default:'null' }},
+    {{ item.bottom_count|default:'null' }}
+);
+
+data["tableColumns{{ item.id }}"] = tableColumns{{ item.id }};
+data["tableItems{{ item.id }}"] = tableItems{{ item.id }};
+</script>

--- a/survey/templates/survey/results_item_table-with-top3.html
+++ b/survey/templates/survey/results_item_table-with-top3.html
@@ -1,5 +1,5 @@
 {% with item_id=item.id|stringformat:'i' %}
-{% with table_items_var='tableItems'|add:item_id %}
+{% with table_items_var='tableItems'|add:item_id table_fields_var='tableColumns'|add:item_id %}
 
 <h5 class="table-title mb-4">{{ item.title }}</h5>
 
@@ -83,7 +83,7 @@
         </div>
     </div>
     <div class="col-md col-12 table-with-top3">
-        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_var item_id=item.id survey=survey main_result_type=item.main_result_type.name|lower only %}
+        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_var table_fields_var=table_fields_var item_id=item.id survey=survey main_result_type=item.main_result_type.name|lower only %}
     </div>
 </div>
 

--- a/survey/templates/survey/results_item_table-with-top3.html
+++ b/survey/templates/survey/results_item_table-with-top3.html
@@ -1,13 +1,13 @@
 {% with item_id=item.id|stringformat:'i' %}
 {% with table_items_var='tableItems'|add:item_id table_fields_var='tableColumns'|add:item_id %}
 
-<h5 class="table-title mb-4">{{ item.title }}</h5>
+<h5 class="table-title mt-4 mb-3">{{ item.title }}</h5>
 
 {% if item.description %}
-    <p class="table-description mt-n4 mb-4">{{ item.description }}</p>
+    <p class="table-description mt-n3 mb-3">{{ item.description }}</p>
 {% endif %}
 
-<div class="row mb-5 justify-content-center" id="results-table-{{ item.id }}">
+<div class="row justify-content-center" id="results-table-{{ item.id }}">
     <div class="col-md-4 col-8 text-center">
         <div v-if="tableItems{{ item.id }}" class="row justify-content-center mb-4">
             <div class="col-8 mb-2">

--- a/survey/templates/survey/results_item_table-with-top3.html
+++ b/survey/templates/survey/results_item_table-with-top3.html
@@ -1,4 +1,5 @@
-{% with table_items_var='items' %}
+{% with item_id=item.id|stringformat:'i' %}
+{% with table_items_var='tableItems'|add:item_id %}
 
 <h5 class="table-title mb-4">{{ item.title }}</h5>
 
@@ -82,39 +83,9 @@
         </div>
     </div>
     <div class="col-md col-12 table-with-top3">
-        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_var survey=survey main_result_type=item.main_result_type.name|lower only %}
+        {% include 'survey/results_item_table-base.html' with table_items_var=table_items_var item_id=item.id survey=survey main_result_type=item.main_result_type.name|lower only %}
     </div>
 </div>
 
-<script>
-const tableMainResult{{ item.id }} = "{{ item.main_result_type.name|lower }}";
-const tableExtraResult{{ item.id }} = "{{ item.extra_result_type.name|lower|default:'' }}";
-
-const tableColumns{{ item.id }} = [
-    columnTypes["rank"],
-    columnTypes["image"],
-    columnTypes["name"],
-].concat(
-    [setColumnCssClass(columnTypes[tableMainResult{{ item.id }}], "table-col-main")],
-    tableExtraResult{{ item.id }} ? [setColumnCssClass(columnTypes[tableExtraResult{{ item.id }}], "table-col-extra")] : []
-);
-
-const tableItems{{ item.id }} = processData(
-    getTableItems({{ item.is_for_series|lower }} ? animeSeriesData : specialAnimeData),
-    tableMainResult{{ item.id }},
-    true,
-    {{ item.top_count|default:'null' }},
-    {{ item.bottom_count|default:'null' }}
-);
-
-new Vue({
-    el: "#results-table-{{ item.id }}",
-    delimiters: ["{$", "$}"],
-    data: {
-        fields: tableColumns{{ item.id }},
-        {{ table_items_var }}: tableItems{{ item.id }},
-    },
-});
-</script>
-
+{% endwith %}
 {% endwith %}

--- a/survey/views/results.py
+++ b/survey/views/results.py
@@ -64,24 +64,27 @@ class ResultsView(BaseResultsView):
     def __get_segments(self):
         survey = self.get_survey()
 
+        # For segments that are post-season survey exclusive
+        _ = lambda segment: EmptySegment() if survey.is_preseason else segment
+
         root_item = SegmentGroup('', is_root=True, children=[
             SegmentGroup('Popularity', [
                 TableWithTop3Segment('Most Popular Anime Series', ResultsType.POPULARITY, top_count=10),
                 TablePairSegment('Biggest Differences in Popularity by Gender', ResultsType.GENDER_POPULARITY_RATIO, ResultsType.POPULARITY, row_count=3, description="Expressed as the ratio of male popularity to female popularity (and vice versa)."),
                 HiddenSegmentGroup('Popularity - Miscellaneous', [
-                    EmptySegment() if survey.is_preseason else TableWithTop3Segment('Most Underwatched Anime', ResultsType.UNDERWATCHED, ResultsType.POPULARITY, top_count=5),
+                    _(TableWithTop3Segment('Most Underwatched Anime', ResultsType.UNDERWATCHED, ResultsType.POPULARITY, top_count=5)),
                     TablePairSegment('Average Age per Anime', ResultsType.AGE, row_count=3),
                 ]),
             ]),
             SegmentGroup('Impressions', [
                 TableWithTop3Segment(('Most (and Least) Anticipated' if survey.is_preseason else 'Best (and Worst)') + ' Anime of the Season', ResultsType.SCORE, top_count=10, bottom_count=5),
                 TablePairSegment('Biggest Differences in Score by Gender', ResultsType.GENDER_SCORE_DIFFERENCE, ResultsType.SCORE, row_count=3, description="Expressed in how much higher an anime was scored by men compared to women (and vice versa)."),
-                EmptySegment() if survey.is_preseason else TableWithTop3Segment('Most Surprising Anime', ResultsType.SURPRISE, ResultsType.SCORE, top_count=5),
-                EmptySegment() if survey.is_preseason else TableWithTop3Segment('Most Disappointing Anime', ResultsType.DISAPPOINTMENT, ResultsType.SCORE, top_count=5),
+                _(TableWithTop3Segment('Most Surprising Anime', ResultsType.SURPRISE, ResultsType.SCORE, top_count=5)),
+                _(TableWithTop3Segment('Most Disappointing Anime', ResultsType.DISAPPOINTMENT, ResultsType.SCORE, top_count=5)),
             ]),
             SegmentGroup('Anime OVAs / ONAs / Movies / Specials', [
                 TableWithTop3Segment('Most Popular Anime OVAs / ONAs / Movies / Specials', ResultsType.POPULARITY, is_for_series=False, top_count=5),
-                EmptySegment() if survey.is_preseason else TableWithTop3Segment('Most Anticipated Anime OVAs / ONAs / Movies / Specials' if survey.is_preseason else 'Best Anime OVAs / ONAs / Movies / Specials', ResultsType.SCORE, is_for_series=False, top_count=5),
+                _(TableWithTop3Segment('Most Anticipated Anime OVAs / ONAs / Movies / Specials' if survey.is_preseason else 'Best Anime OVAs / ONAs / Movies / Specials', ResultsType.SCORE, is_for_series=False, top_count=5)),
             ]),
         ])
 
@@ -159,7 +162,6 @@ class SegmentGroup(Segment):
 class HiddenSegmentGroup(SegmentGroup):
     def __init__(self, title, children=[], is_root=False):
         super().__init__(title, children, is_root, SegmentType.HIDDEN_GROUP)
-
 
 
 class TableBaseSegment(Segment):

--- a/survey/views/results.py
+++ b/survey/views/results.py
@@ -68,7 +68,7 @@ class ResultsView(BaseResultsView):
             SegmentGroup('Popularity', [
                 TableWithTop3Segment('Most Popular Anime Series', ResultsType.POPULARITY, top_count=10),
                 TablePairSegment('Biggest Differences in Popularity by Gender', ResultsType.GENDER_POPULARITY_RATIO, ResultsType.POPULARITY, row_count=3, description="Expressed as the ratio of male popularity to female popularity (and vice versa)."),
-                SegmentGroup('Popularity - Miscellaneous', [
+                HiddenSegmentGroup('Popularity - Miscellaneous', [
                     EmptySegment() if survey.is_preseason else TableWithTop3Segment('Most Underwatched Anime', ResultsType.UNDERWATCHED, ResultsType.POPULARITY, top_count=5),
                     TablePairSegment('Average Age per Anime', ResultsType.AGE, row_count=3),
                 ]),
@@ -125,6 +125,7 @@ class ResultsView(BaseResultsView):
 class SegmentType(Enum):
     EMPTY = auto()
     GROUP = auto()
+    HIDDEN_GROUP = auto()
     TABLE_WITH_TOP3 = auto()
     TABLE_PAIR = auto()
 
@@ -143,11 +144,9 @@ class EmptySegment(Segment):
         super().__init__(SegmentType.EMPTY, None)
 
 class SegmentGroup(Segment):
-    def __init__(self, title, children=[], is_root=False):
-        super().__init__(SegmentType.GROUP, title)
-
+    def __init__(self, title, children=[], is_root=False, item_type=SegmentType.GROUP):
+        super().__init__(item_type, title)
         self.children = children
-
         if is_root:
             self._set_id(0)
     
@@ -156,6 +155,10 @@ class SegmentGroup(Segment):
         for child in self.children:
             next_id = child._set_id(next_id)
         return next_id
+
+class HiddenSegmentGroup(SegmentGroup):
+    def __init__(self, title, children=[], is_root=False):
+        super().__init__(title, children, is_root, SegmentType.HIDDEN_GROUP)
 
 
 


### PR DESCRIPTION
Adds popularity and score rankings for male and female people on the results page.

The full results page also has the ability to display these gender-specific results, but since the series results table won't fit on the page displaying those columns is disabled.