### PR TITLE
Bump django to 3.2.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django_htmlmin==0.11.0
 django_allauth==0.47.0
 django_sass==1.1.0
-Django==3.2.11
+Django==3.2.12
 Pillow==9.0.1


### PR DESCRIPTION
beep boop discount dependabot here

There's a security advisory out that says we should bump from Django 3.2.11 to 3.2.12, but Dependabot is refusing to make a PR for it because it wants to bump us all the way up to Django 4 instead of using the fix version that doesn't have breaking changes. I'm manually making a PR for 3.2.12 so the security advisory will get out of my notifications.