### PR TITLE
Various fixes 2

### DIFF
--- a/frontend/src/views/surveyform/SurveyForm.vue
+++ b/frontend/src/views/surveyform/SurveyForm.vue
@@ -221,9 +221,13 @@ export default class SurveyForm extends Vue {
   // scrolls down the page and hits 'Submit' only to be greeted with a generic error message,
   // while the error is all the way up on the page
   clampAge(): void {
-    if (this.surveyFormData?.responseData?.age && _.isNumber(this.surveyFormData.responseData.age)) {
-      // Assume the user typo'd and get the first two numbers, and then clamp
-      this.surveyFormData.responseData.age = Math.max(10, Math.min(80, Number(this.surveyFormData.responseData.age.toString().slice(0, 2))));
+    if (this.surveyFormData?.responseData?.age != null) {
+      if (_.isNumber(this.surveyFormData.responseData.age)) {
+        // Assume the user typo'd and get the first two numbers, and then clamp
+        this.surveyFormData.responseData.age = Math.max(10, Math.min(80, Number(this.surveyFormData.responseData.age.toString().slice(0, 2))));
+      } else {
+        this.surveyFormData.responseData.age = null;
+      }
     }
   }
 

--- a/frontend/src/views/surveyform/data/survey-form-data.ts
+++ b/frontend/src/views/surveyform/data/survey-form-data.ts
@@ -1,16 +1,16 @@
 import { AnimeData, SurveyData } from "@/util/data";
 
 export interface ResponseData {
-  age?: number;
-  gender?: string;
+  age: number | null;
+  gender: string | null;
 }
 
 export interface AnimeResponseData {
   animeId: number;
-  score: number;
+  score: number | null;
   watching: boolean;
-  underwatched?: boolean;
-  expectations?: string;
+  underwatched: boolean | null;
+  expectations: string | null;
 }
 
 export interface SurveyFormBaseData {

--- a/survey/views/api/survey_form.py
+++ b/survey/views/api/survey_form.py
@@ -5,7 +5,9 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from django.http.request import HttpRequest
+from django.utils.decorators import method_decorator
 from django.utils.functional import classproperty
+from django.views.decorators.cache import never_cache
 from django.views.generic import View
 from hashlib import sha512
 from http import HTTPStatus
@@ -18,8 +20,10 @@ from survey.util.http import HttpEmptyErrorResponse, JsonErrorResponse
 from survey.util.survey import try_get_survey, get_survey_anime
 from typing import Any, Callable, Optional
 
+
 # TODO: In the future unauthenticated users should still be able to see the survey
 #       but not be able to respond to the survey
+@method_decorator(never_cache, name='dispatch')
 class SurveyFormApi(View):
     def get(self, request: HttpRequest, *args, **kwargs):
         if not request.user.is_authenticated:


### PR DESCRIPTION
* Should fix #103 by never caching old survey response data
* Prevent #102 from happening by adding an auth check when obtaining survey form data - PR #101 should have prevented frontend user data not being in sync with the backend, by preventing user data from being cached, however the issue still remained for a few hours. While the specific use case described should no longer be possible, comments and such need to be monitored for mentions of something that may be a result of this issue
* Move all auth checks and checks whether the survey is open for the user away from the frontend
* Fix a bug where the frontend sends an empty string in the 'age' field on a survey response, causing exceptions