### PR TITLE
Dockerize

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Build and publish Docker images
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    # Build multiple containers; map Dockerfile stages to published image names
+    strategy:
+      matrix:
+        include:
+          - target-stage: backend
+            image-name: survey-backend
+          - target-stage: static
+            image-name: survey-static
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image-name }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          target: ${{ matrix.target-stage }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:lts AS frontend
+
+WORKDIR /build
+COPY ./frontend /build
+RUN npm ci
+RUN npm run build
+
+# ---
+
+FROM python:3.11-alpine AS survey-api
+RUN apk add build-base python3-dev jpeg-dev zlib-dev libffi-dev
+ENV LIBRARY_PATH=/lib:/usr/lib
+
+WORKDIR /app
+COPY requirements.txt /app
+RUN pip3 install -r requirements.txt gunicorn --no-cache-dir
+
+COPY . /app
+COPY --from=frontend /build/dist /app/frontend/dist
+RUN DJANGO_SECRET_KEY=static python3 ./manage.py collectstatic
+EXPOSE 8000
+ENTRYPOINT ["python3"]
+CMD ["/usr/local/bin/gunicorn", "surveysite.wsgi", "--bind", "0.0.0.0:8000"]
+
+# ---
+
+FROM nginx:alpine AS survey-static
+
+COPY --from=survey-api /app/static /usr/share/nginx/html
+COPY ./static-nginx.conf /etc/nginx/conf.d/default.conf
+RUN find /usr/share/nginx/html -type f | xargs gzip -k
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts AS frontend
+FROM node:lts AS frontend-builder
 
 WORKDIR /build
 COPY ./frontend /build
@@ -7,7 +7,7 @@ RUN npm run build
 
 # ---
 
-FROM python:3.11-alpine AS survey-api
+FROM python:3.11-alpine AS backend
 RUN apk add build-base python3-dev jpeg-dev zlib-dev libffi-dev
 ENV LIBRARY_PATH=/lib:/usr/lib
 
@@ -16,7 +16,7 @@ COPY requirements.txt /app
 RUN pip3 install -r requirements.txt gunicorn --no-cache-dir
 
 COPY . /app
-COPY --from=frontend /build/dist /app/frontend/dist
+COPY --from=frontend-builder /build/dist /app/frontend/dist
 RUN DJANGO_SECRET_KEY=static python3 ./manage.py collectstatic
 EXPOSE 8000
 ENTRYPOINT ["python3"]
@@ -24,9 +24,9 @@ CMD ["/usr/local/bin/gunicorn", "surveysite.wsgi", "--bind", "0.0.0.0:8000"]
 
 # ---
 
-FROM nginx:alpine AS survey-static
+FROM nginx:alpine AS static
 
-COPY --from=survey-api /app/static /usr/share/nginx/html
+COPY --from=backend /app/static /usr/share/nginx/html
 COPY ./static-nginx.conf /etc/nginx/conf.d/default.conf
 RUN find /usr/share/nginx/html -type f | xargs gzip -k
 EXPOSE 80

--- a/static-nginx.conf
+++ b/static-nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        gzip_static  on;
+        try_files  $uri $uri.html $uri/index.html =404;
+    }
+
+    error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Adds a multi-stage dockerfile for compose-based deployment.  This was written and tested on a call with @eritbh, and we verified it to work together.

This is intended to be deployed as two containers (the `backend` target and `static` target) with traffic for `/static/` being routed to the static nginx container (it listens on port 80), and all other traffic routed to the api container (which listens on port 8000).  This can be handled by using a docker-local network or via publishing ports.

The `frontend` container image should not be deployed, as it does not have the `CMD` declaration necessary for it to actually run.  It is only used as an intermediary container which copies results to the `survey-api` container.

***Note:*** we have not added the Github Actions pipeline to build and publish these images.  We intend to finish that tomorrow, at which point it will be ready to merge.