### PR TITLE
docker: Run migrations before starting server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,26 @@ RUN npm run build
 # ---
 
 FROM python:3.11-alpine AS backend
+
 RUN apk add build-base python3-dev jpeg-dev zlib-dev libffi-dev
 ENV LIBRARY_PATH=/lib:/usr/lib
 
 WORKDIR /app
+# install python dependencies from project requirements.txt
 COPY requirements.txt /app
 RUN pip3 install -r requirements.txt gunicorn --no-cache-dir
 
+# pull in the actual app
+# TODO: refine this to pull in less things
 COPY . /app
+
+# pull in built frontend files and drop them into the django static directory
 COPY --from=frontend-builder /build/dist /app/frontend/dist
 RUN DJANGO_SECRET_KEY=static python3 ./manage.py collectstatic
+
 EXPOSE 8000
-ENTRYPOINT ["python3"]
-CMD ["/usr/local/bin/gunicorn", "surveysite.wsgi", "--bind", "0.0.0.0:8000"]
+CMD python3 ./manage.py migrate \
+ && python3 /usr/local/bin/gunicorn surveysite.wsgi --bind 0.0.0.0:8000
 
 # ---
 


### PR DESCRIPTION
Updates the dockerfile to run migrations before the web server starts. This uses [the shell form of `CMD`](https://docs.docker.com/engine/reference/builder/#shell-form) to run multiple commands. The `ENTRYPOINT` is removed since it's not meant to be used with shell-form `CMD`, which is fine because nobody was doing manual `docker run`s on this container until now anyway.

Draft until I actually test this